### PR TITLE
Feat/add null column detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@
 > ✅ **Timeseries column exploration**
 `Get summary statistics such as Start date, End date, estimated granularity of the timeseries (day,month,year), null values for timeseries columns`
 
+✅ **Find Null Columns**
+`Identifies columns containing null values or empty strings in a dbt model. Works as an ad-hoc model or as a post-hook logger.`
+
 ✅ **Debug Preview during dbt build/run**
 
 > ✅ **Get row count**
@@ -253,6 +256,67 @@ describe('model_name', include=None, column_filter=None)
  ```
  Filters the column metadata for the specific columns. In this case, the meta data for is_short_string, country and str_length columns are returned.
  ```
+
+### Find Null Columns
+
+```sh
+find_null_columns(model_name=None, column_filter=None)
+
+ Scans a model for columns containing null values or empty strings ('' for string columns).
+ Only columns with at least one null or empty value are returned, ordered by count descending.
+ column_filter is an optional list of column names to restrict the analysis to.
+```
+
+### [Example 1](examples/public/find_null_columns/find_null_columns_ex1.sql)
+> ➡️ Input
+```sh
+{{dbt_eda_tools.find_null_columns('set_null_values_columns')}}
+```
+
+> ⬅️ Output
+
+| column_name          | null_or_empty_count | pct_null_or_empty | total_rows |
+|----------------------|--------------------:|------------------:|-----------:|
+| col1_as_null         | 54800               | 100.0             | 54800      |
+| col2_as_empty_string | 54800               | 100.0             | 54800      |
+| col3_as_some_null    | 10960               | 20.0              | 54800      |
+
+> 👓 Explanation
+```
+Scans all columns in set_null_values_columns. String columns are checked for both nulls and empty strings ('').
+Non-string columns (numeric, date, boolean) are checked for nulls only.
+Only columns with at least one null or empty value appear in the output.
+```
+
+### [Example 2](examples/public/find_null_columns/find_null_columns_ex1.sql) — with column_filter
+> ➡️ Input
+```sh
+{{dbt_eda_tools.find_null_columns('set_null_values_columns', column_filter=['col2_as_empty_string', 'col3_as_some_null'])}}
+```
+
+> 👓 Explanation
+```
+Restricts the scan to the specified columns only.
+Useful when you want to monitor specific columns rather than scanning the entire model.
+```
+
+### Post-hook usage
+> ➡️ Input
+```sh
+dbt_project.yml
+----------------
+models:
+  +post-hook:
+      - "{{ dbt_eda_tools.find_null_columns() }}"
+```
+
+> 👓 Explanation
+```
+When called without arguments, find_null_columns runs as a post-hook after each model build.
+It prints a formatted table of null/empty columns to the terminal.
+Requires dbt_eda_tools_log_enable: true in your dbt_project.yml vars.
+If no null or empty columns are found, nothing is printed.
+```
 
 ## Debug/Preview in the terminal
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_eda_tools"
-version: "1.4.0"
+version: "1.4.1"
 
 profile: "dbt_eda_tools_bq"
 

--- a/docs/superpowers/plans/2026-05-11-find-null-columns.md
+++ b/docs/superpowers/plans/2026-05-11-find-null-columns.md
@@ -1,0 +1,295 @@
+# find_null_columns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `find_null_columns` macro to `dbt_eda_tools` that reports columns with null values, callable both as a `dbt run-operation` and as a post-hook logger.
+
+**Architecture:** A single macro in `macros/find_null_columns.sql` that detects its invocation mode by whether `model_name` is provided (ad-hoc) or absent (post-hook using `this`). It queries `INFORMATION_SCHEMA.COLUMNS` to discover column names, then executes a single-scan SQL statement computing null counts per column, filtered to only columns where `null_count > 0`. Results are rendered via `print_pretty_table`.
+
+**Tech Stack:** dbt Jinja macros, BigQuery / Snowflake / DuckDB SQL, `dbt_utils.get_query_results_as_dict`, `run_query`, `print_pretty_table`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `macros/find_null_columns.sql` | Main macro — both invocation modes |
+| Modify | `macros/schema.yml` | Document new macro arguments |
+
+---
+
+### Task 1: Write the core `find_null_columns` macro (ad-hoc mode)
+
+**Files:**
+- Create: `macros/find_null_columns.sql`
+
+- [ ] **Step 1: Create the macro file with the ad-hoc entry point**
+
+Create `macros/find_null_columns.sql` with this content:
+
+```jinja
+{% macro find_null_columns(model_name=None, column_filter=None) %}
+    {{ return(adapter.dispatch('find_null_columns', 'dbt_eda_tools')(model_name, column_filter)) }}
+{% endmacro %}
+
+{% macro default__find_null_columns(model_name, column_filter) %}
+
+    {# ── Post-hook mode: no model_name supplied, use `this` ── #}
+    {% if model_name is none %}
+        {% if this is none or this.name is none %}
+            {% do return('') %}
+        {% endif %}
+        {% if not var('dbt_eda_tools_log_enable', false) %}
+            {% do return('') %}
+        {% endif %}
+        {% set target_relation = this %}
+        {% set display_name = this.name %}
+        {% set information_metadata = ((dbt_eda_tools.fetch_information_metadata(this.name)) | replace("'", "") | replace("[", " ") | replace("]", " ") | trim).split(',') %}
+    {# ── Ad-hoc mode: model_name supplied ── #}
+    {% else %}
+        {% if not execute or not load_relation(ref(model_name)) %}
+            {% do return('') %}
+        {% endif %}
+        {% set target_relation = ref(model_name) %}
+        {% set display_name = model_name %}
+        {% set information_metadata = ((dbt_eda_tools.fetch_information_metadata(model_name)) | replace("'", "") | replace("[", " ") | replace("]", " ") | trim).split(',') %}
+    {% endif %}
+
+    {% set full_path = information_metadata[0] | trim %}
+    {% set table_name = information_metadata[1] | trim %}
+    {% set db_name = dbt_eda_tools.fetch_db() | trim %}
+
+    {# ── Step 1: discover column names from INFORMATION_SCHEMA ── #}
+    {% set column_query %}
+        SELECT column_name
+        FROM {{ full_path }}.COLUMNS
+        WHERE table_name = '{{ table_name }}'
+        {% if column_filter %}
+            AND column_name IN (
+                {% for col in column_filter -%}
+                '{{ col }}'{% if not loop.last %},{% endif %}
+                {%- endfor %}
+            )
+        {% endif %}
+        ORDER BY ordinal_position
+    {% endset %}
+
+    {% set col_key = 'COLUMN_NAME' if db_name == 'snowflake' else 'column_name' %}
+    {% set col_results = dbt_utils.get_query_results_as_dict(column_query) %}
+    {% set columns = col_results[col_key] %}
+
+    {% if not columns or columns | length == 0 %}
+        {{ log("find_null_columns: no columns found for " ~ display_name, info=True) }}
+        {% do return('') %}
+    {% endif %}
+
+    {# ── Step 2: single-scan null count query ── #}
+    {% set countif_fn = 'COUNT_IF' if db_name in ('snowflake', 'duckdb') else 'COUNTIF' %}
+
+    {% set null_query %}
+        WITH null_counts AS (
+            SELECT
+                COUNT(*) AS total_rows
+                {% for col in columns %}
+                , {{ countif_fn }}({{ col }} IS NULL) AS {{ col }}__null_count
+                {% endfor %}
+            FROM {{ target_relation }}
+        )
+        {% for col in columns %}
+        SELECT
+            '{{ col }}' AS column_name
+            , {{ col }}__null_count AS null_count
+            , ROUND({{ col }}__null_count * 100.0 / NULLIF(total_rows, 0), 2) AS pct_null
+            , total_rows
+        FROM null_counts
+        WHERE {{ col }}__null_count > 0
+        {{ 'UNION ALL' if not loop.last else '' }}
+        {% endfor %}
+        ORDER BY null_count DESC
+    {% endset %}
+
+    {% set null_results = run_query(null_query) %}
+
+    {# ── Step 3: render output ── #}
+    {% if null_results and null_results.rows | length > 0 %}
+        {% set headers = ['column_name', 'null_count', 'pct_null', 'total_rows'] %}
+        {% set rows = [] %}
+        {% for row in null_results.rows %}
+            {% set formatted_row = [
+                row[0] | string,
+                row[1] | string,
+                row[2] | string ~ '%',
+                row[3] | string
+            ] %}
+            {% if rows.append(formatted_row) %}{% endif %}
+        {% endfor %}
+        {{ log("\033[1;32m " ~ display_name ~ " — null columns:\033[0m", info=True) }}
+        {{ dbt_eda_tools.print_pretty_table(headers, rows) }}
+    {% else %}
+        {{ log("\033[1;32m✓ No null columns in " ~ display_name ~ "\033[0m", info=True) }}
+    {% endif %}
+
+{% endmacro %}
+```
+
+- [ ] **Step 2: Verify the file was created**
+
+```bash
+ls macros/find_null_columns.sql
+```
+Expected: file listed.
+
+- [ ] **Step 3: Compile to catch Jinja syntax errors**
+
+```bash
+dbt compile
+```
+Expected: `Done. PASS=...` with no Jinja errors. Ignore any model errors — models are disabled in this package.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add macros/find_null_columns.sql
+git commit -m "feat: add find_null_columns macro (ad-hoc and post-hook modes)"
+```
+
+---
+
+### Task 2: Document the macro in `schema.yml`
+
+**Files:**
+- Modify: `macros/schema.yml`
+
+- [ ] **Step 1: Add the macro entry to `macros/schema.yml`**
+
+Open `macros/schema.yml`. After the last `- name:` block (currently `estimate_build_cost`), append:
+
+```yaml
+
+  - name: find_null_columns
+    description: >
+      Finds columns containing null values in a dbt model or view.
+      Can be called as a run-operation (ad-hoc) or used as a post-hook logger.
+      Only columns with at least one null are reported. Results include column_name,
+      null_count, pct_null (as percentage), and total_rows.
+      Post-hook mode requires dbt_eda_tools_log_enable var to be true.
+    arguments:
+      - name: model_name
+        type: string
+        description: >
+          The dbt model to inspect. Required for ad-hoc mode (dbt run-operation).
+          Omit entirely when using as a post-hook — the macro will use `this` automatically.
+      - name: column_filter
+        type: list
+        description: >
+          Optional list of column names to restrict the analysis to.
+          Example: ['order_id', 'shipped_at']. Only applies in ad-hoc mode.
+```
+
+- [ ] **Step 2: Compile to confirm schema.yml is valid**
+
+```bash
+dbt compile
+```
+Expected: `Done. PASS=...` with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add macros/schema.yml
+git commit -m "docs: document find_null_columns in schema.yml"
+```
+
+---
+
+### Task 3: Manual smoke test — ad-hoc mode
+
+> This package targets BigQuery. You need an active dbt profile (`dbt_eda_tools_bq`) and a compiled model available as a ref.
+
+**Files:** none (testing only)
+
+- [ ] **Step 1: Check what example models exist**
+
+```bash
+ls examples/
+```
+The `examples/` directory contains staging models. Pick any model name that resolves via `ref()` in your dev environment.
+
+- [ ] **Step 2: Run ad-hoc against a model with known nulls**
+
+```bash
+dbt run-operation find_null_columns --args '{model_name: <your_model_name>}'
+```
+Expected output: a formatted table printed to console listing only columns where `null_count > 0`, e.g.:
+```
+ <model_name> — null columns:
+-------------------------------------------------------
+ column_name   | null_count | pct_null | total_rows
+-------------------------------------------------------
+ shipped_at    | 430        | 4.30%    | 10000
+```
+
+- [ ] **Step 3: Run with column_filter**
+
+```bash
+dbt run-operation find_null_columns --args '{model_name: <your_model_name>, column_filter: [<col1>, <col2>]}'
+```
+Expected: same table format, scoped only to the listed columns.
+
+- [ ] **Step 4: Run against a model with no nulls**
+
+```bash
+dbt run-operation find_null_columns --args '{model_name: <clean_model_name>}'
+```
+Expected console output:
+```
+✓ No null columns in <clean_model_name>
+```
+
+---
+
+### Task 4: Manual smoke test — post-hook mode
+
+**Files:** none (testing only)
+
+- [ ] **Step 1: Enable the log var and run a model**
+
+In your project's `dbt_project.yml` (or via `--vars`), set `dbt_eda_tools_log_enable: true`, then run a model:
+
+```bash
+dbt run --select <your_model_name> --vars '{dbt_eda_tools_log_enable: true}'
+```
+Expected: after the model runs, null columns are printed to the console (or the "no nulls" message if clean).
+
+- [ ] **Step 2: Confirm it is silent when var is false**
+
+```bash
+dbt run --select <your_model_name> --vars '{dbt_eda_tools_log_enable: false}'
+```
+Expected: no null column output printed — macro exits silently.
+
+---
+
+### Task 5: Final commit and version bump (optional)
+
+**Files:**
+- Modify: `dbt_project.yml`
+
+- [ ] **Step 1: Bump the patch version in `dbt_project.yml`**
+
+Open `dbt_project.yml`. Change:
+```yaml
+version: "1.4.0"
+```
+to:
+```yaml
+version: "1.5.0"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add dbt_project.yml
+git commit -m "chore: bump version to 1.5.0 for find_null_columns release"
+```

--- a/docs/superpowers/specs/2026-05-11-find-null-columns-design.md
+++ b/docs/superpowers/specs/2026-05-11-find-null-columns-design.md
@@ -1,0 +1,119 @@
+---
+title: find_null_columns macro
+date: 2026-05-11
+status: approved
+---
+
+# Design: `find_null_columns` macro
+
+## Summary
+
+A new macro for `dbt_eda_tools` that identifies columns containing null values in a dbt model or view. Supports two invocation modes: ad-hoc query (via `dbt run-operation`) and post-hook logger (fires automatically after model build when `dbt_eda_tools_log_enable` is true).
+
+---
+
+## Invocation Modes
+
+### Ad-hoc (run-operation)
+
+```bash
+dbt run-operation find_null_columns --args '{model_name: my_model}'
+dbt run-operation find_null_columns --args '{model_name: my_model, column_filter: [col_a, col_b]}'
+```
+
+- `model_name` (string, required): the dbt model to inspect
+- `column_filter` (list, optional): restrict analysis to specific columns
+- Returns a result set filtered to only columns where `null_count > 0`
+- Output columns: `column_name`, `null_count`, `pct_null`, `total_rows`
+
+### Post-hook
+
+```jinja
+{{ dbt_eda_tools.find_null_columns() }}
+```
+
+- No arguments — uses `this` (the model currently being materialized)
+- Only fires when `var('dbt_eda_tools_log_enable', false)` is `true`
+- Prints a formatted table to the console via `print_pretty_table`
+- If no nulls found, logs: `✓ No null columns in <model_name>`
+
+---
+
+## Architecture
+
+### File
+
+`macros/find_null_columns.sql`
+
+### Single macro, dual mode
+
+`find_null_columns(model_name=None, column_filter=None)`
+
+- When `model_name` is provided: ad-hoc mode, uses `ref(model_name)`
+- When `model_name` is None: post-hook mode, uses `this`
+- Guards: returns early if `this is none` (post-hook) or relation doesn't exist (ad-hoc)
+- Dispatches via `adapter.dispatch('find_null_columns', 'dbt_eda_tools')` for cross-adapter support
+
+### Execution flow
+
+1. Resolve `full_path`, `table_name`, `db_name` via `fetch_information_metadata` + `fetch_db` (same as `describe`)
+2. Query `INFORMATION_SCHEMA.COLUMNS` to get all column names (or subset if `column_filter` provided)
+3. Build a single SQL statement — one `COUNTIF(col IS NULL)` expression per column + `COUNT(*)` for total rows — one table scan
+4. Wrap in a CTE, filter to `null_count > 0`
+5. Ad-hoc: execute via `run_query`, render with `print_pretty_table` and return
+6. Post-hook: execute, print result or "no nulls" message, no return value
+
+### Cross-adapter SQL
+
+`COUNTIF` (BigQuery), `COUNT_IF` (Snowflake/DuckDB), `SUM(CASE WHEN col IS NULL THEN 1 ELSE 0 END)` fallback — consistent with the branching in `fetch_column_metadata.sql:72`.
+
+---
+
+## Output
+
+### Console (post-hook)
+
+```
+| column_name  | null_count | pct_null |
+| order_id     | 1240       | 12.40%   |
+| shipped_at   | 430        | 4.30%    |
+```
+
+### Result set (ad-hoc)
+
+| column_name | null_count | pct_null | total_rows |
+|-------------|------------|----------|------------|
+| order_id    | 1240       | 12.40    | 10000      |
+| shipped_at  | 430        | 4.30     | 10000      |
+
+Only rows where `null_count > 0` are included in both modes.
+
+---
+
+## Schema doc (`macros/schema.yml`)
+
+New entry added:
+
+```yaml
+- name: find_null_columns
+  description: >
+    Finds columns containing null values in a dbt model or view.
+    Can be called as a run-operation (ad-hoc) or used as a post-hook logger.
+    Only columns with at least one null are reported.
+    Post-hook mode requires dbt_eda_tools_log_enable: true.
+  arguments:
+    - name: model_name
+      type: string
+      description: The dbt model to inspect. Required for ad-hoc mode; omit for post-hook mode.
+    - name: column_filter
+      type: list
+      description: Optional list of column names to restrict the analysis to.
+```
+
+---
+
+## What is NOT in scope
+
+- No changes to `dbt_project.yml` post-hook list (opt-in via `dbt_eda_tools_log_enable` var only)
+- No new tests beyond what exists in the package today
+- No support for non-dbt tables (raw BigQuery table refs outside of `ref()`)

--- a/examples/1.intermediate/find_null_columns/set_null_values_columns.sql
+++ b/examples/1.intermediate/find_null_columns/set_null_values_columns.sql
@@ -1,0 +1,13 @@
+{# Create some fake missing dates at the granularity of the day #}
+WITH
+null_value_cols AS (
+    SELECT *
+    , NUll as col1_as_null
+    , '' AS col2_as_empty_string
+    , CASE 
+        WHEN str_length = 5 THEN NULL 
+        ELSE str_length 
+    END AS col3_as_some_null
+    FROM {{ ref('data_generator_enriched_describe') }}
+)
+SELECT * FROM null_value_cols

--- a/examples/public/find_null_columns/find_null_columns_ex1.sql
+++ b/examples/public/find_null_columns/find_null_columns_ex1.sql
@@ -1,0 +1,1 @@
+{{dbt_eda_tools.find_null_columns('set_null_values_columns')}}

--- a/macros/find_null_columns.sql
+++ b/macros/find_null_columns.sql
@@ -1,0 +1,159 @@
+{% macro find_null_columns(model_name=None, column_filter=None) %}
+    {% if model_name is none %}
+        {# Post-hook mode: returns empty string (side-effect only) #}
+        {{ return(adapter.dispatch('find_null_columns_posthook', 'dbt_eda_tools')(column_filter)) }}
+    {% else %}
+        {# Ad-hoc model body mode: renders SQL directly #}
+        -- depends_on: {{ ref(model_name) }}
+        {{ return(adapter.dispatch('find_null_columns', 'dbt_eda_tools')(model_name, column_filter)) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro default__find_null_columns(model_name, column_filter) %}
+    {# Ad-hoc mode: renders SQL so dbt can materialize results as a view/table #}
+    {% if not execute or not load_relation(ref(model_name)) %}
+        SELECT CAST(NULL AS STRING) AS column_name, CAST(NULL AS STRING) AS issue_type, 0 AS null_or_empty_count, 0.0 AS pct_null_or_empty, 0 AS total_rows WHERE FALSE
+    {% else %}
+        {% set target_relation = ref(model_name) %}
+        {% set information_metadata = ((dbt_eda_tools.fetch_information_metadata(model_name)) | replace("'", "") | replace("[", " ") | replace("]", " ") | trim).split(',') %}
+        {% set full_path = information_metadata[0] | trim %}
+        {% set table_name = information_metadata[1] | trim %}
+        {% set db_name = dbt_eda_tools.fetch_db() | trim %}
+
+        {% set column_query %}
+            SELECT column_name, data_type
+            FROM {{ full_path }}.COLUMNS
+            WHERE table_name = '{{ table_name }}'
+            {% if column_filter %}
+                AND column_name IN (
+                    {% for col in column_filter -%}
+                    '{{ col }}'{% if not loop.last %},{% endif %}
+                    {%- endfor %}
+                )
+            {% endif %}
+            ORDER BY ordinal_position
+        {% endset %}
+
+        {% set col_key = 'COLUMN_NAME' if db_name == 'snowflake' else 'column_name' %}
+        {% set dtype_key = 'DATA_TYPE' if db_name == 'snowflake' else 'data_type' %}
+        {% set col_results = dbt_utils.get_query_results_as_dict(column_query) %}
+        {% set columns = col_results[col_key] %}
+        {% set data_types = col_results[dtype_key] %}
+
+        {% if not columns or columns | length == 0 %}
+            SELECT CAST(NULL AS STRING) AS column_name, CAST(NULL AS STRING) AS issue_type, 0 AS null_or_empty_count, 0.0 AS pct_null_or_empty, 0 AS total_rows WHERE FALSE
+        {% else %}
+            {% set string_types = ['STRING', 'VARCHAR', 'TEXT', 'CHAR', 'CHARACTER', 'NVARCHAR'] %}
+            {% set countif_fn = 'COUNT_IF' if db_name in ('snowflake', 'duckdb') else 'COUNTIF' %}
+            WITH null_counts AS (
+                SELECT
+                    COUNT(*) AS total_rows
+                    {% for col in columns %}
+                    {% set is_string = data_types[loop.index0] | upper in string_types %}
+                    , {{ countif_fn }}(
+                        `{{ col }}` IS NULL{% if is_string %} OR CAST(`{{ col }}` AS STRING) = ''{% endif %}
+                    ) AS `{{ col }}__null_or_empty_count`
+                    {% endfor %}
+                FROM {{ target_relation }}
+            )
+            {% for col in columns %}
+            SELECT
+                '{{ col }}' AS column_name
+                , `{{ col }}__null_or_empty_count` AS null_or_empty_count
+                , ROUND(`{{ col }}__null_or_empty_count` * 100.0 / NULLIF(total_rows, 0), 2) AS pct_null_or_empty
+                , total_rows
+            FROM null_counts
+            WHERE `{{ col }}__null_or_empty_count` > 0
+            {{ 'UNION ALL' if not loop.last else '' }}
+            {% endfor %}
+            ORDER BY null_or_empty_count DESC
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
+{% macro default__find_null_columns_posthook(column_filter) %}
+    {# Post-hook mode: executes query and prints results, returns empty string #}
+    {% if this is none or this.name is none %}
+        {% do return('') %}
+    {% endif %}
+    {% if not var('dbt_eda_tools_log_enable', false) %}
+        {% do return('') %}
+    {% endif %}
+
+    {% set information_metadata = ((dbt_eda_tools.fetch_information_metadata(this.name)) | replace("'", "") | replace("[", " ") | replace("]", " ") | trim).split(',') %}
+    {% set full_path = information_metadata[0] | trim %}
+    {% set table_name = information_metadata[1] | trim %}
+    {% set db_name = dbt_eda_tools.fetch_db() | trim %}
+
+    {% set column_query %}
+        SELECT column_name, data_type
+        FROM {{ full_path }}.COLUMNS
+        WHERE table_name = '{{ table_name }}'
+        {% if column_filter %}
+            AND column_name IN (
+                {% for col in column_filter -%}
+                '{{ col }}'{% if not loop.last %},{% endif %}
+                {%- endfor %}
+            )
+        {% endif %}
+        ORDER BY ordinal_position
+    {% endset %}
+
+    {% set col_key = 'COLUMN_NAME' if db_name == 'snowflake' else 'column_name' %}
+    {% set dtype_key = 'DATA_TYPE' if db_name == 'snowflake' else 'data_type' %}
+    {% set col_results = dbt_utils.get_query_results_as_dict(column_query) %}
+    {% set columns = col_results[col_key] %}
+    {% set data_types = col_results[dtype_key] %}
+
+    {% if not columns or columns | length == 0 %}
+        {{ log("find_null_columns: no columns found for " ~ this.name, info=True) }}
+        {% do return('') %}
+    {% endif %}
+
+    {% set string_types = ['STRING', 'VARCHAR', 'TEXT', 'CHAR', 'CHARACTER', 'NVARCHAR'] %}
+    {% set countif_fn = 'COUNT_IF' if db_name in ('snowflake', 'duckdb') else 'COUNTIF' %}
+
+    {% set null_query %}
+        WITH null_counts AS (
+            SELECT
+                COUNT(*) AS total_rows
+                {% for col in columns %}
+                {% set is_string = data_types[loop.index0] | upper in string_types %}
+                , {{ countif_fn }}(
+                    `{{ col }}` IS NULL{% if is_string %} OR CAST(`{{ col }}` AS STRING) = ''{% endif %}
+                ) AS `{{ col }}__null_or_empty_count`
+                {% endfor %}
+            FROM {{ this }}
+        )
+        {% for col in columns %}
+        SELECT
+            '{{ col }}' AS column_name
+            , `{{ col }}__null_or_empty_count` AS null_or_empty_count
+            , ROUND(`{{ col }}__null_or_empty_count` * 100.0 / NULLIF(total_rows, 0), 2) AS pct_null_or_empty
+            , total_rows
+        FROM null_counts
+        WHERE `{{ col }}__null_or_empty_count` > 0
+        {{ 'UNION ALL' if not loop.last else '' }}
+        {% endfor %}
+        ORDER BY null_or_empty_count DESC
+    {% endset %}
+
+    {% set null_results = run_query(null_query) %}
+
+    {% if null_results and null_results.rows | length > 0 %}
+        {% set headers = ['column_name', 'null_or_empty_count', 'pct_null_or_empty', 'total_rows'] %}
+        {% set rows = [] %}
+        {% for row in null_results.rows %}
+            {% set formatted_row = [
+                row[0] | string,
+                row[1] | string,
+                row[2] | string ~ '%',
+                row[3] | string
+            ] %}
+            {% if rows.append(formatted_row) %}{% endif %}
+        {% endfor %}
+        {{ dbt_eda_tools.print_pretty_table(headers, rows) }}
+    {% endif %}
+
+    {% do return('') %}
+{% endmacro %}

--- a/tests/find_null_columns/assert_find_null_columns_detects_empty_strings.sql
+++ b/tests/find_null_columns/assert_find_null_columns_detects_empty_strings.sql
@@ -1,0 +1,17 @@
+-- Asserts that string columns containing empty strings ('') are detected.
+-- col2_as_empty_string is a STRING column set to '' for every row.
+-- Returns rows on failure (column missing or count is zero).
+WITH result AS (
+    {{ dbt_eda_tools.find_null_columns('set_null_values_columns') }}
+)
+SELECT *
+FROM result
+WHERE
+    column_name = 'col2_as_empty_string'
+    AND null_or_empty_count = 0
+UNION ALL
+SELECT CAST(NULL AS STRING) AS column_name, 0 AS null_or_empty_count, 0.0 AS pct_null_or_empty, 0 AS total_rows
+FROM (SELECT 1 AS _dummy)
+WHERE NOT EXISTS (
+    SELECT 1 FROM result WHERE column_name = 'col2_as_empty_string'
+)

--- a/tests/find_null_columns/assert_find_null_columns_detects_nulls.sql
+++ b/tests/find_null_columns/assert_find_null_columns_detects_nulls.sql
@@ -1,0 +1,15 @@
+-- Asserts that columns with null values are detected.
+-- col1_as_null is 100% null, col3_as_some_null has partial nulls.
+-- Returns rows on failure (expected column missing from results).
+WITH result AS (
+    {{ dbt_eda_tools.find_null_columns('set_null_values_columns') }}
+)
+, expected AS (
+    SELECT 'col1_as_null' AS column_name
+    UNION ALL
+    SELECT 'col3_as_some_null'
+)
+SELECT expected.column_name
+FROM expected
+LEFT JOIN result USING (column_name)
+WHERE result.column_name IS NULL

--- a/tests/find_null_columns/assert_find_null_columns_excludes_clean_columns.sql
+++ b/tests/find_null_columns/assert_find_null_columns_excludes_clean_columns.sql
@@ -1,0 +1,9 @@
+-- Asserts that columns with no nulls or empty strings do not appear in results.
+-- date_day, company_name, country, str_length, is_short_string have no nulls/empties
+-- in the base data_generator_enriched_describe source.
+WITH result AS (
+    {{ dbt_eda_tools.find_null_columns('set_null_values_columns') }}
+)
+SELECT column_name
+FROM result
+WHERE column_name IN ('date_day', 'company_name', 'country', 'str_length', 'is_short_string')

--- a/tests/find_null_columns/assert_find_null_columns_output_columns.sql
+++ b/tests/find_null_columns/assert_find_null_columns_output_columns.sql
@@ -1,0 +1,12 @@
+-- Asserts the result has the expected 4 output columns with correct names.
+-- Returns rows on failure (any unexpected column name present).
+WITH result AS (
+    {{ dbt_eda_tools.find_null_columns('set_null_values_columns') }}
+)
+SELECT *
+FROM result
+WHERE
+    column_name IS NULL
+    OR null_or_empty_count IS NULL
+    OR pct_null_or_empty IS NULL
+    OR total_rows IS NULL


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a new `find_null_columns` macro to `dbt_eda_tools` to identify columns with nulls or empty strings, usable ad‑hoc or as a post-hook logger. Updates docs, examples, tests, and bumps version to `1.4.1`.

- **New Features**
  - `find_null_columns(model_name=None, column_filter=None)` reports `column_name`, `null_or_empty_count`, `pct_null_or_empty`, and `total_rows`.
  - Works in two modes:
    - Ad‑hoc: `dbt run-operation find_null_columns --args '{model_name: my_model}'`.
    - Post-hook: `{{ dbt_eda_tools.find_null_columns() }}`; prints a table when `dbt_eda_tools_log_enable` is true.
  - Supports optional `column_filter` to scan specific columns; checks empty strings for string types.
  - Cross-adapter SQL with a single table scan; examples and README updated; added tests to validate behavior.

- **Migration**
  - No breaking changes. To use as a post-hook, add `+post-hook: "{{ dbt_eda_tools.find_null_columns() }}"` and set `dbt_eda_tools_log_enable: true` in `vars`.

<sup>Written for commit c31d3b0a426f8c035a3627dd2ebb4e6f61e71635. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

