### PR TITLE
added backtick to bigquery columns to prevent breaks when column name…

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_eda_tools"
-version: "1.4.1"
+version: "1.4.2"
 
 profile: "dbt_eda_tools_bq"
 

--- a/macros/estimated_granularity.sql
+++ b/macros/estimated_granularity.sql
@@ -1,9 +1,9 @@
-{% macro estimated_granularity(model_name, date_col) %}
-    {{ return(adapter.dispatch('estimated_granularity', 'dbt_eda_tools')(model_name, date_col)) }}
+{% macro estimated_granularity(model_name, date_col, db_name='bigquery') %}
+    {{ return(adapter.dispatch('estimated_granularity', 'dbt_eda_tools')(model_name, date_col, db_name)) }}
 {% endmacro %}
 
-{% macro default__estimated_granularity(model_name, date_col) %}
-
+{% macro default__estimated_granularity(model_name, date_col, db_name) %}
+    {% set quoted_col = dbt_eda_tools.quote_column(date_col, db_name) %}
     SELECT
         lag_bucketed AS estimated_granularity
         , {{dbt_eda_tools.percent_of_total('count_total','sum',3)}} AS estimated_granularity_confidence
@@ -19,10 +19,10 @@
                 , COUNT(*) AS count_total
             FROM (
                 SELECT
-                    {{date_col}}
-                    , {{datediff( 'LAG(' + date_col +',1) OVER (ORDER BY '+date_col+')', date_col, 'day')}} AS lags_day
+                    {{quoted_col}}
+                    , {{datediff( 'LAG(' + quoted_col +',1) OVER (ORDER BY '+ quoted_col +')', quoted_col, 'day')}} AS lags_day
                 FROM (
-                    SELECT DISTINCT {{date_col}}
+                    SELECT DISTINCT {{quoted_col}}
                     FROM {{ ref(model_name) }}
                 )
             )

--- a/macros/fetch_column_metadata.sql
+++ b/macros/fetch_column_metadata.sql
@@ -30,35 +30,37 @@
     {% if results[conditional_col_name] %}
         {# construct the column detail results #}
         {% for col_name in results[conditional_col_name]%}
+            {% set quoted_col = dbt_eda_tools.quote_column(col_name, db_name) %}
+            {% set cte_name = dbt_eda_tools.safe_cte_name(col_name) %}
 
             {% if data_type == 'date'%}
-                {% set results_granularity = dbt_utils.get_query_results_as_dict(dbt_eda_tools.estimated_granularity(model_name, col_name) ) %}
+                {% set results_granularity = dbt_utils.get_query_results_as_dict(dbt_eda_tools.estimated_granularity(model_name, col_name, db_name) ) %}
             {% endif %}
 
 
-            column_detail_{{col_name}} AS (
+            {{cte_name}} AS (
                 SELECT
                     1
                     {% if data_type in ('text','boolean') %}
-                        , {{col_name}}
+                        , {{quoted_col}}
                         , COUNT(*) AS cnt
                     {%  elif data_type in ('numeric','date') %}
-                            , MIN({{col_name}}) AS min
-                            , MAX({{col_name}}) AS max
+                            , MIN({{quoted_col}}) AS min
+                            , MAX({{quoted_col}}) AS max
                             {%  if data_type == 'numeric' %}
-                                , ROUND(AVG({{col_name}}),4) AS avg
+                                , ROUND(AVG({{quoted_col}}),4) AS avg
                                 {% if db_name == 'snowflake' %}
-                                , ROUND(TO_VARCHAR(APPROX_PERCENTILE({{col_name}}, 0.25),'999.999999'),4) AS percentile_25
-                                , ROUND(TO_VARCHAR(APPROX_PERCENTILE({{col_name}}, 0.5),'999.999999'),4) AS percentile_50
-                                , ROUND(TO_VARCHAR(APPROX_PERCENTILE({{col_name}}, 0.75),'999.999999'),4) AS percentile_75
+                                , ROUND(TO_VARCHAR(APPROX_PERCENTILE({{quoted_col}}, 0.25),'999.999999'),4) AS percentile_25
+                                , ROUND(TO_VARCHAR(APPROX_PERCENTILE({{quoted_col}}, 0.5),'999.999999'),4) AS percentile_50
+                                , ROUND(TO_VARCHAR(APPROX_PERCENTILE({{quoted_col}}, 0.75),'999.999999'),4) AS percentile_75
                                 {% elif db_name == 'duckdb' %}
-                                , ROUND(APPROX_QUANTILE({{col_name}}, 0.25),4) AS percentile_25
-                                , ROUND(APPROX_QUANTILE({{col_name}}, 0.5),4) AS percentile_50
-                                , ROUND(APPROX_QUANTILE({{col_name}}, 0.75),4) AS percentile_75
+                                , ROUND(APPROX_QUANTILE({{quoted_col}}, 0.25),4) AS percentile_25
+                                , ROUND(APPROX_QUANTILE({{quoted_col}}, 0.5),4) AS percentile_50
+                                , ROUND(APPROX_QUANTILE({{quoted_col}}, 0.75),4) AS percentile_75
                                 {% elif db_name == 'bigquery' %}
-                                , ROUND(APPROX_QUANTILES({{col_name}}, 100)[OFFSET(25)],4) AS percentile_25
-                                , ROUND(APPROX_QUANTILES({{col_name}}, 100)[OFFSET(50)],4) AS percentile_50
-                                , ROUND(APPROX_QUANTILES({{col_name}}, 100)[OFFSET(75)],4) AS percentile_75
+                                , ROUND(APPROX_QUANTILES({{quoted_col}}, 100)[OFFSET(25)],4) AS percentile_25
+                                , ROUND(APPROX_QUANTILES({{quoted_col}}, 100)[OFFSET(50)],4) AS percentile_50
+                                , ROUND(APPROX_QUANTILES({{quoted_col}}, 100)[OFFSET(75)],4) AS percentile_75
                                 {% endif %}
                             {%  elif data_type == 'date' %}
                                 , MIN('{{results_granularity[conditional_estimated_granularity_name][0]}}') AS estimated_granularity
@@ -67,9 +69,9 @@
                     {% endif %}
 
 
-                    , SUM(COUNT({{col_name}})) OVER () AS cnt_total
-                    , SUM(COUNT(DISTINCT {{col_name}})) OVER () AS cnt_unique
-                    , {{'COUNT_IF' if db_name in ('snowflake','duckdb') else 'COUNTIF'}}({{col_name}} IS NULL) AS cnt_null
+                    , SUM(COUNT({{quoted_col}})) OVER () AS cnt_total
+                    , SUM(COUNT(DISTINCT {{quoted_col}})) OVER () AS cnt_unique
+                    , {{'COUNT_IF' if db_name in ('snowflake','duckdb') else 'COUNTIF'}}({{quoted_col}} IS NULL) AS cnt_null
 
                 FROM {{ref(model_name)}}
 
@@ -86,7 +88,9 @@
         {# turn the results into a json object #}
         , {{output_name}} AS (
             {% for col_name in results[conditional_col_name] %}
-            {% set non_null_json_key = "COALESCE("+col_name+","+("'NULL'" if data_type != 'boolean' else 'false')+")" %}
+            {% set quoted_col = dbt_eda_tools.quote_column(col_name, db_name) %}
+            {% set cte_name = dbt_eda_tools.safe_cte_name(col_name) %}
+            {% set non_null_json_key = "COALESCE("+quoted_col+","+("'NULL'" if data_type != 'boolean' else 'false')+")" %}
             SELECT
                 '{{col_name}}' AS column_name
                 , {{'OBJECT_CONSTRUCT' if db_name == 'snowflake' else 'JSON_OBJECT'}}(
@@ -117,7 +121,7 @@
                         {% endif %}
                     {% endif %}
                 ) AS detail
-            FROM column_detail_{{col_name}}
+            FROM {{cte_name}}
             {{ 'UNION ALL' if not loop.last else ''}}
         {% endfor %}
 

--- a/macros/quote_column.sql
+++ b/macros/quote_column.sql
@@ -1,0 +1,14 @@
+{% macro quote_column(col_name, db_name) %}
+  {%- if db_name == 'snowflake' -%}
+    "{{ col_name }}"
+  {%- elif db_name in ('bigquery', 'duckdb') -%}
+    `{{ col_name }}`
+  {%- else -%}
+    {{ col_name }}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro safe_cte_name(col_name) %}
+  {%- set sanitized = col_name | replace(' ', '_') -%}
+  col_{{ sanitized }}
+{%- endmacro %}


### PR DESCRIPTION
…s start with integers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quotes column identifiers for BigQuery/DuckDB with backticks and Snowflake with double quotes to prevent failures when names start with numbers or include spaces. Adds a quoting helper, applies it in key macros, and bumps `dbt_eda_tools` to 1.4.2.

- **Bug Fixes**
  - Added `quote_column` (backticks for `bigquery`/`duckdb`, double quotes for `snowflake`) and `safe_cte_name`.
  - Applied quoting in `estimated_granularity`; added `db_name` arg (default `bigquery`) and passed through from callers.
  - Applied quoting and `safe_cte_name` in `fetch_column_metadata` to avoid invalid identifiers and CTE names.

<sup>Written for commit 71c47ec085a9c5165d8bd38f442e3ef0a6ab1c97. Summary will update on new commits. <a href="https://cubic.dev/pr/shankararul/dbt_eda_tools/pull/32?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

